### PR TITLE
chore(renovate): switch to globally maintained config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,23 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: [
-    "config:recommended",
-    ":automergeDisabled",
-    ":semanticCommits",
-    ":dependencyDashboard",
-    ":enablePreCommit",
-  ],
-  schedule: ["every weekend"],
-  platformAutomerge: false,
-  prHourlyLimit: 6,
-  prConcurrentLimit: 20,
-  customManagers: [
-    {
-      "customType": "regex",
-      "fileMatch": ["\.sh",],
-      "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s(?<originalPackageName>.*?)=\"(?<currentValue>.*?)\""
-      ],
-    },
-  ]
+  extends: ["github>camunda/infex-common-config:default.json5"],
 }

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,16 @@
+################################################################################
+#                                                                              #
+# Note: when adding a new tool here, also adjust the Renovate configuration    #
+#       that mirrors some asdf plugin's logic to remove version prefixes like  #
+#       "v".                                                                   #
+#                                                                              #
+#       You have to amend the Renovate config when the asdf plugin takes 1.2.3 #
+#       as the version but the Docker tag/Github tag is actually v1.2.3        #
+#                                                                              #
+################################################################################
+
 # /!\ Please maintain this file sorted alphabetically.
 # check it with
 # diff <(sed '/^#/d; /^$/d' .tool-versions | sort) <(sed '/^#/d; /^$/d' .tool-versions) && echo ".tool-versions is sorted correctly" || echo ".tool-versions is not sorted correctly"
 
-# renovate: datasource=github-releases depName=pre-commit/pre-commit
 pre-commit 3.7.1


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/196

Switches to a globally maintained renovate config.