### PR TITLE
chore: release 8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Usage: ./checks/zeebe/connectivity.sh [-h] [-H ZEEBE_ADDRESS] [-p ZEEBE_VERSION]
 Options:
   -h                                    Display this help message
   -H ZEEBE_ADDRESS                      Specify the Zeebe address and optional port (e.g., zeebe.c8.camunda.example.com:443)
-  -p ZEEBE_VERSION                      Specify the Zeebe version (default is the latest version: 8.8 - major.minor only)
+  -p ZEEBE_VERSION                      Specify the Zeebe version (default is the latest version: 8.9 - major.minor only)
   -f PROTO_FILE                         Specify the path to the gateway.proto file or leave empty to download it (default behavior is to download the proto file)
   -k                                    Skip TLS verification (insecure mode)
   -r CACERT                             Specify the path to the CA certificate file

--- a/checks/zeebe/connectivity.sh
+++ b/checks/zeebe/connectivity.sh
@@ -25,7 +25,7 @@ API_PROTOCOL="${API_PROTOCOL:-"grpc"}"
 ZEEBE_ADDRESS="${ZEEBE_ADDRESS:-""}"
 
 # TODO: [release-duty] before the release, update this! Only major-minor due to stable branch naming from upstream camunda/camunda
-ZEEBE_DEFAULT_VERSION="8.8"
+ZEEBE_DEFAULT_VERSION="8.9"
 ZEEBE_VERSION="${ZEEBE_VERSION:-$ZEEBE_DEFAULT_VERSION}"
 
 # Function to display script usage


### PR DESCRIPTION
This pull request updates the default Zeebe version from 8.8 to 8.9 in both the documentation and the connectivity check script to reflect the latest release.

Version update:

* Updated the default Zeebe version in the `README.md` usage instructions to 8.9.
* Changed the `ZEEBE_DEFAULT_VERSION` in `checks/zeebe/connectivity.sh` from 8.8 to 8.9.