### PR TITLE
fix(aws-irsa): read identityKeycloak.image.repository directly

### DIFF
--- a/checks/kube/aws-irsa.sh
+++ b/checks/kube/aws-irsa.sh
@@ -857,9 +857,13 @@ check_irsa_aurora_requirements() {
                     echo "[OK] $component.postgresql.enabled is correctly set to false in your helm values."
                 fi
 
-                keycloak_image=$(echo "$HELM_CHART_VALUES" | jq -r ".identityKeycloak.image // empty")
+                # Read the repository field directly: when user values set
+                # only sub-keys like image.pullSecrets without overriding
+                # repository, ".identityKeycloak.image" resolves to a non-empty
+                # JSON object and the defaults fallback never fires.
+                keycloak_image=$(echo "$HELM_CHART_VALUES" | jq -r ".identityKeycloak.image.repository // empty")
                 if [[ -z "$keycloak_image" || "$keycloak_image" == "null" ]]; then
-                    keycloak_image=$(echo "$HELM_CHART_DEFAULT_VALUES" | jq -r ".identityKeycloak.image // empty")
+                    keycloak_image=$(echo "$HELM_CHART_DEFAULT_VALUES" | jq -r ".identityKeycloak.image.repository // empty")
                 fi
 
                 if [[ -z "$keycloak_image" || "$keycloak_image" == "null" ]]; then


### PR DESCRIPTION
## Summary

The IRSA image check at `checks/kube/aws-irsa.sh:860` reads `.identityKeycloak.image` as a whole object. When user values override sub-keys like `image.pullSecrets` (e.g. Docker Hub auth) without setting `.repository`, jq returns a non-empty JSON object, the defaults fallback never fires, and the substring match for `camunda/keycloak` fails:

```
[FAIL] The identityKeycloak.image must contain 'camunda/keycloak' in its name to support IRSA tooling.
```

This blocks `camunda-deployment-references` EKS IRSA tests whenever user values inject pull secrets.

Fix: read `.identityKeycloak.image.repository` directly, with the same fallback to chart defaults.

## Test plan
- [x] Manual repro on the failing CI run (helm get values returns `identityKeycloak.image: {pullSecrets: [{name: index-docker-io}]}`)
- [x] Re-run `aws-kubernetes-eks-single-region-irsa` integration tests once merged