### PR TITLE
fix(connectivity): fall back to main when stable/${ZEEBE_VERSION} branch is missing

### DIFF
--- a/checks/zeebe/connectivity.sh
+++ b/checks/zeebe/connectivity.sh
@@ -183,12 +183,27 @@ if [ "$API_PROTOCOL" = "grpc" ]; then
     download_zeebe_protofile(){
         echo "[INFO] Downloading gateway.proto for zeebe=${ZEEBE_VERSION}..."
 
+        local stable_url="https://raw.githubusercontent.com/camunda/camunda/refs/heads/stable/${ZEEBE_VERSION}/zeebe/gateway-protocol/src/main/proto/gateway.proto"
+        local main_url="https://raw.githubusercontent.com/camunda/camunda/refs/heads/main/zeebe/gateway-protocol/src/main/proto/gateway.proto"
+
         local curl_download_command
-        curl_download_command="curl -f \"https://raw.githubusercontent.com/camunda/camunda/refs/heads/stable/${ZEEBE_VERSION}/zeebe/gateway-protocol/src/main/proto/gateway.proto\" -o \"$PROTO_FILE\""
+        curl_download_command="curl -f \"${stable_url}\" -o \"$PROTO_FILE\""
         echo "[INFO] Running command: ${curl_download_command}"
 
         if eval "${curl_download_command}"; then
             echo "[INFO] Successfuly downloaded proto file for Zeebe=${ZEEBE_VERSION}"
+            return
+        fi
+
+        # Fallback to main: stable/<version> may not exist yet for unreleased
+        # versions (e.g. development against the next minor before its branch
+        # cut), in which case the proto file is only available on main.
+        echo "[WARN] stable/${ZEEBE_VERSION} branch not available, falling back to main"
+        curl_download_command="curl -f \"${main_url}\" -o \"$PROTO_FILE\""
+        echo "[INFO] Running command: ${curl_download_command}"
+
+        if eval "${curl_download_command}"; then
+            echo "[INFO] Successfuly downloaded proto file for Zeebe=${ZEEBE_VERSION} from main"
         else
             echo "[FAIL] Failed to downloaded proto file for Zeebe=${ZEEBE_VERSION}" 1>&2
             SCRIPT_STATUS_OUTPUT=3


### PR DESCRIPTION
## Summary

`checks/zeebe/connectivity.sh` downloads `gateway.proto` from `stable/${ZEEBE_VERSION}` of `camunda/camunda`. When testing against an unreleased version (e.g. 8.10 before its branch cut), the `stable/8.10` branch does not exist, the curl 404s, and gRPC connectivity check fails:

```
[INFO] Downloading gateway.proto for zeebe=8.10...
[FAIL] Failed to downloaded proto file for Zeebe=8.10
[FAIL] gRPC connectivity
```

This is currently breaking AKS/EKS integration tests on `camunda-deployment-references` `main` (chart targets the next minor).

Fix: try `stable/${ZEEBE_VERSION}` first, fall back to `main` if that 404s. The proto path on `main` is identical.

## Test plan
- [x] Verified `stable/8.10` returns 404 and `main` returns 200 for the same path
- [ ] Re-run `aws-kubernetes-eks-single-region` / `azure-kubernetes-aks-single-region` integration tests once merged