### PR TITLE
chore(deps): update camunda/infraex-common-config to 2.0.1

### DIFF
--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
     call-todo-checker:
-        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Notify in Slack in case of failure
               id: slack-notification
               if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
     lint:
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit


### PR DESCRIPTION
Re-pins every `camunda/infraex-common-config` reusable workflow and composite action from `1.8.0` to `2.0.1` (`4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5`).

- Release: https://github.com/camunda/infraex-common-config/releases/tag/2.0.1
- Diff: https://github.com/camunda/infraex-common-config/compare/1.8.0...2.0.1