### PR TITLE
ci: add zizmor to pre-commit [ready]

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,42 @@
+---
+# =============================================================================
+# zizmor.yml — GitHub Actions supply-chain policy for camunda/c8-sm-checks
+#
+# Consumed by the `zizmor` pre-commit hook (see .pre-commit-config.yaml), which
+# runs locally on `pre-commit run -a` and in CI through lint-global.
+#
+# Mirrors the policy adopted in camunda/infraex-common-config#562, itself
+# mirroring camunda/infra-global-github-actions#781.
+#
+# The binding constraint is not our own threat model but GitHub's `Require
+# actions to be pinned to a full-length commit SHA` setting, which several
+# repositories in this organisation enforce and which grants no exemption:
+#
+#   "all actions must be pinned to a full-length commit SHA to be used. This
+#    includes actions from your organization and actions authored by GitHub.
+#    Reusable workflows can still be referenced by tag."
+#
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+#
+# That check is evaluated over the whole dependency tree at `Set up job`, so a
+# tag left inside a third-party composite action refuses the job before any step
+# runs, and the caller cannot work around it.
+#
+# Docs: https://docs.zizmor.sh/configuration/
+# =============================================================================
+
+rules:
+    unpinned-uses:
+        config:
+            # `policies` maps action-owner globs to a pinning level.
+            #
+            #   any       — no constraint; any ref (SHA, tag, branch) is accepted.
+            #   ref-pin   — must carry an explicit ref, symbolic (tag/branch) or SHA.
+            #   hash-pin  — must be a 40-character commit SHA. Tags and branches fail.
+            #
+            # Local references (`uses: ./.github/actions/...`) are same-repo and are
+            # skipped by this audit entirely, so they need no policy entry.
+            policies:
+                # Everything is hash-pinned, with no namespace exemption, including
+                # `actions/*` and this organisation's own repositories.
+                '*': hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,28 @@ repos:
       hooks:
           - id: actionlint-docker
 
+    - repo: https://github.com/zizmorcore/zizmor-pre-commit
+      rev: v1.29.0
+      hooks:
+          # Static analysis of GitHub Actions workflows and actions, mirroring the hook adopted
+          # in camunda/infraex-common-config#551. It covers what actionlint does not: injection
+          # through template expansion, excessive GITHUB_TOKEN permissions, credential
+          # persistence and unpinned action references. actionlint also only reads
+          # `.github/workflows/`, so composite actions are linted by nothing without it.
+          #
+          # Threshold is `high`, which this repository already meets with no code change; the
+          # remaining medium and low findings are a separate burn-down.
+          #
+          # Without GH_TOKEN zizmor runs offline, which skips known-vulnerable-actions,
+          # impostor-commit, ref-confusion, ref-version-mismatch and stale-action-refs.
+          # None of those currently report anything at `high`.
+          #
+          # --config makes the pinning policy explicit in .github/zizmor.yml rather than leaving
+          # it to zizmor's defaults, so a future default change cannot silently drop
+          # `unpinned-uses` below the threshold above.
+          - id: zizmor
+            args: [--no-progress, --min-severity=high, --config=.github/zizmor.yml]
+
     - repo: https://github.com/renovatebot/pre-commit-hooks
       rev: 43.288.0
       hooks:


### PR DESCRIPTION
Part of the zizmor rollout across the infraex repositories, following its adoption in camunda/infraex-common-config#551 / #562.

## Why zizmor on top of actionlint

They do not overlap. actionlint checks workflow syntax and runs shellcheck on `run:` blocks; zizmor audits the security semantics — injection through template expansion, excessive `GITHUB_TOKEN` permissions, credential persistence through `actions/checkout`, unpinned action references.

It also reads composite actions. actionlint only walks `.github/workflows/`, so any `action.yml` this repository grows later would be linted by nothing.

## Cost here: zero

This repository is already clean at `--min-severity=high` — no workflow change is needed, the hook just keeps it that way. The remaining findings are medium and low (`artipacked`: checkouts without `persist-credentials: false`, and `${{ steps.*.outputs }}` interpolation), left for a separate burn-down rather than smuggled into an enablement PR.

## `.github/zizmor.yml`

States the `unpinned-uses` policy explicitly (`hash-pin` for every namespace, `actions/*` and `camunda/*` included) instead of relying on zizmor's default. It changes no finding today, since every reference here is already SHA-pinned; it stops a future change of that default from silently dropping the audit below the threshold.

That policy is not a preference: GitHub's `Require actions to be pinned to a full-length commit SHA` setting is evaluated over the *whole* dependency tree at `Set up job`, so a tag left inside a third-party composite action refuses the job before any step runs. camunda/keycloak lost two CI runs to exactly that this month, both times through a reference two levels below anything the repository writes itself.

Without `GH_TOKEN` zizmor runs offline, which skips `known-vulnerable-actions`, `impostor-commit`, `ref-confusion`, `ref-version-mismatch` and `stale-action-refs`. None of those reports anything at `high` here.

## Verification

`pre-commit run --all-files` is clean, zizmor hook included. Renovate tracks the hook revision through `:enablePreCommit` in the shared preset.
