### PR TITLE
ci: scope GITHUB_TOKEN to least privilege in workflows [ready]

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,10 +10,22 @@ on:
         paths:
             - .github/workflows/links.yml
 
+# The repository default is `default_workflow_permissions: write`, so without this block the job
+# below runs with a read/write GITHUB_TOKEN. The link check itself only reads; the scheduled
+# failure path needs more and escalates on the job.
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: links-check
         runs-on: ubuntu-latest
+        # `issues: write` is for the scheduled failure path only: `create-issue-from-file` opens
+        # the "Link Checker Report" issue, and `report-failure-on-slack` reads the
+        # `silence: <workflow>` issues to decide whether the alert is muted.
+        permissions:
+            contents: read
+            issues: write
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               with:


### PR DESCRIPTION
Same treatment as camunda/keycloak#633, closing the `excessive-permissions` findings zizmor reports here.

## Problem

The repository default is `default_workflow_permissions: write`, so `links-check` ran with a `GITHUB_TOKEN` that can push to `main`, open issues and comment on pull requests — to check links. It also runs on every `push`, on every branch.

## Change

`contents: read` at the workflow level, with one escalation on the job.

`issues: write` is needed on the scheduled failure path only, and it is not cosmetic:

- `create-issue-from-file` opens the "Link Checker Report" issue;
- `report-failure-on-slack` reads the open `silence: <workflow>` issues to decide whether the alert is muted. Without it the action logs a warning and alerts anyway, so a workflow someone deliberately silenced would start paging again.

The lychee token is unaffected: it only reads, to lift the GitHub API rate limit while resolving links.

## Deliberately untouched

`lint.yml` and `internal_global_pr_todo_checker.yml` call reusable workflows from `infraex-common-config`. Those declare their own permissions, and a caller-level `permissions` block caps the callee rather than complementing it. They stay as the only two findings, same call as in camunda/keycloak#633.

## Verification

- `zizmor --min-severity=medium`: `excessive-permissions` 3 → 2.
- `pre-commit run --all-files` clean.
- `links.yml` runs on `push`, so this PR exercises the changed workflow directly.
