### PR TITLE
ci: pass the lint-global secrets explicitly [ready]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,11 @@ on:
 
 jobs:
     lint:
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
-        secrets: inherit
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@6aec6cec54de76653072d6c30792437995a07128 # 2.3.1
+        # Explicit rather than `secrets: inherit`, which hands every secret this repository holds
+        # to a workflow whose main job installs and executes third-party pre-commit hook code.
+        # These three are all it reads, and only on the auto-fix path.
+        secrets:
+            VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+            VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+            VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
Finishes the `secrets-inherit` burn-down. The `todo-checker-global` half landed with the `persist-credentials` PR; this is the other one, unblocked by camunda/infraex-common-config#571 (released as 2.3.1).

## Why it was stuck

`lint-global` reads `VAULT_ADDR`, `VAULT_ROLE_ID` and `VAULT_SECRET_ID` but declared no `secrets:` block under `workflow_call`. A reusable workflow only sees secrets that were declared or inherited, so `secrets: inherit` was the only option — and it passes **every** secret this repository holds.

## Why it matters here

The `pre-commit` job of that workflow installs and executes hook code coming from this repository. camunda/infraex-common-config#550 already took the App token away from that job for exactly that reason; the inherited secret set was the remaining part of the same exposure.

## Change

Two lines of substance: pin bumped from 2.0.1 to 2.3.1 — required to reach the declaration — and the three secrets passed by name.

Checked before bumping:

- job names are unchanged (`lint / pre-commit`, `lint / Commit pre-commit fixes`), so required checks are unaffected;
- 2.3.1 adds a step asserting that the caller pins `pre-commit` in `.tool-versions`; this repository pins `pre-commit 4.6.1`, so it passes.

The rest of the 2.0.1 → 2.3.1 range is the trust split in `lint-global` (#563, #569, #570), which this repository was going to pick up through Renovate anyway.

## Verification

`zizmor --min-severity=medium`: `secrets-inherit` 1 → 0. The lint workflow runs on this PR, so the bump is exercised directly.
