### PR TITLE
fix(kube): skip headless services in the connectivity sweep

### DIFF
--- a/checks/kube/connectivity.sh
+++ b/checks/kube/connectivity.sh
@@ -68,8 +68,9 @@ check_services_resolution() {
     local services
     local services_command
     # we only take the first port as we only want to check service name resolution and nothing else
-    # clusterIP is carried along so headless services can be skipped below
-    services_command="kubectl get services -n \"$NAMESPACE\" -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.ports[0].port}:{.spec.clusterIP}{\"\n\"}{end}'"
+    # clusterIP comes first so headless services can be skipped below; it is emitted
+    # first on purpose, see the right-to-left parsing in the loop
+    services_command="kubectl get services -n \"$NAMESPACE\" -o jsonpath='{range .items[*]}{.spec.clusterIP}:{.metadata.name}:{.spec.ports[0].port}{\"\n\"}{end}'"
     echo "[INFO] Running command: ${services_command}"
     services=$(eval "${services_command}")
 
@@ -87,10 +88,14 @@ check_services_resolution() {
         fi
 
         for service in $services; do
-            local service_cluster_ip="${service##*:}"
-            local service_without_ip="${service%:*}"
-            local service_name="${service_without_ip%:*}"
-            local service_port="${service_without_ip##*:}"
+            # Parsed right to left: a service name and a port never contain a
+            # colon, so whatever remains on the left is the cluster IP, colons
+            # included. That keeps IPv6 and dual-stack clusters working, where
+            # clusterIP looks like fd00:10:96::1.
+            local service_port="${service##*:}"
+            local service_rest="${service%:*}"
+            local service_name="${service_rest##*:}"
+            local service_cluster_ip="${service_rest%:*}"
 
             # Headless services (clusterIP None) publish the pod IPs of their
             # ready endpoints instead of a virtual IP, so their DNS name has no

--- a/checks/kube/connectivity.sh
+++ b/checks/kube/connectivity.sh
@@ -68,7 +68,8 @@ check_services_resolution() {
     local services
     local services_command
     # we only take the first port as we only want to check service name resolution and nothing else
-    services_command="kubectl get services -n \"$NAMESPACE\" -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.ports[0].port}{\"\n\"}{end}'"
+    # clusterIP is carried along so headless services can be skipped below
+    services_command="kubectl get services -n \"$NAMESPACE\" -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.ports[0].port}:{.spec.clusterIP}{\"\n\"}{end}'"
     echo "[INFO] Running command: ${services_command}"
     services=$(eval "${services_command}")
 
@@ -86,8 +87,23 @@ check_services_resolution() {
         fi
 
         for service in $services; do
-            local service_name="${service%:*}"
-            local service_port="${service#*:}"
+            local service_cluster_ip="${service##*:}"
+            local service_without_ip="${service%:*}"
+            local service_name="${service_without_ip%:*}"
+            local service_port="${service_without_ip##*:}"
+
+            # Headless services (clusterIP None) publish the pod IPs of their
+            # ready endpoints instead of a virtual IP, so their DNS name has no
+            # A record at all while the backing workload has no ready pod. A
+            # probe then fails with "Name or service not known", which reports a
+            # rollout in progress rather than a connectivity problem. Every
+            # workload that owns a headless service is also fronted by a regular
+            # service, so skipping these loses no coverage.
+            if [ "$service_cluster_ip" = "None" ]; then
+                echo "[INFO] Skipping headless service $service_name:$service_port (no cluster IP; resolution depends on ready endpoints)"
+                continue
+            fi
+
             echo "[INFO] Checking service $service_name:$service_port from pod $pod"
 
             local check_output


### PR DESCRIPTION
## Problem

`connectivity.sh` fails the whole sweep with exit 2 on a single probe:

```
[FAIL] Service camunda-connectors-headless:8080 resolution failed from pod elasticsearch-es-masters-0
bash: line 1: camunda-connectors-headless: Name or service not known
bash: line 1: /dev/tcp/camunda-connectors-headless/8080: Invalid argument
...
[FAIL] ./checks/kube/connectivity.sh: At least one of the tests failed (error code: 2).
```

This is not a connectivity fault. A headless service (`clusterIP: None`) has no virtual IP; its DNS A record is assembled from the pod IPs of its **ready** endpoints. While the backing workload has no ready pod, the name has no A record at all, and `Name or service not known` is the correct DNS answer.

The proof is in the two adjacent probes of the same run. The regular service resolves, the headless one does not, one second apart:

```
[OK]   Service camunda-connectors:8080 resolved successfully from pod elasticsearch-es-masters-0
[FAIL] Service camunda-connectors-headless:8080 resolution failed from pod elasticsearch-es-masters-0
```

A cluster IP resolves regardless of endpoints, which is why only the headless variant can exhibit this. In that run Connectors was mid-rollout:

```
camunda-connectors-8596bfd96-m9vk5   1/1 Running 2 restarts -> Terminating
camunda-connectors-5bf74b7bcf-cdrbw  0/1 ContainerCreating -> 1/1 Running
```

## Impact

One probe out of 349 fails the entire check. It is recurrent and not tied to any particular change:

- [camunda-deployment-references#2963](https://github.com/camunda/camunda-deployment-references/pull/2963), ROSA, failed from `elasticsearch-es-masters-0`.
- An unrelated ROSA run, [32263114495](https://github.com/camunda/camunda-deployment-references/actions/runs/32263114495), failed the same probe from five pods at once: `elasticsearch-es-masters-1`, `elasticsearch-es-masters-2`, `pg-identity-1`, `pg-keycloak-1`, `pg-webmodeler-1`.

[camunda-deployment-references#3116](https://github.com/camunda/camunda-deployment-references/issues/3116) tracks the same family of pod-churn-induced check failures, and reports that on `stable/8.8` the operator-based lane fails 4 runs out of 5.

## Change

Carry `clusterIP` alongside the name and port, and skip services that have none:

```
{range .items[*]}{.metadata.name}:{.spec.ports[0].port}:{.spec.clusterIP}{"\n"}{end}
```

The filtering is done in the loop rather than in the JSONPath expression, so the behaviour stays explicit and readable, and it does not depend on the edge cases of JSONPath filters over absent fields.

## No coverage is lost

Every workload owning a headless service is also fronted by a regular one, so each is still probed. From the same namespace:

| Workload | Headless, now skipped | Regular, still probed |
| --- | --- | --- |
| Connectors | `camunda-connectors-headless` | `camunda-connectors` |
| Orchestration | `camunda-zeebe` | `camunda-zeebe-gateway` |
| Elasticsearch | `elasticsearch-es-transport`, `elasticsearch-es-masters` | `elasticsearch-es-http`, `elasticsearch-es-internal-http` |
| Keycloak | `keycloak-discovery` | `keycloak-service` |

`ExternalName` services carry no `clusterIP` either, but the field is empty rather than `None`, so they keep being probed exactly as before.

## Validation

- `shellcheck` and `pre-commit` pass.
- The parsing and skip logic was exercised in isolation over cluster IP, headless, and `ExternalName` shapes:

  ```
  PROBE  camunda-connectors            port=8080   clusterIP=10.0.0.1
  SKIP   camunda-connectors-headless   port=8080   clusterIP=None
  SKIP   elasticsearch-es-transport    port=9300   clusterIP=None
  PROBE  keycloak-service              port=18080  clusterIP=10.0.0.2
  PROBE  some-externalname             port=443    clusterIP=<none>
  PROBE  camunda-zeebe-gateway         port=9600   clusterIP=10.0.0.3
  ```

## Note

This removes a class of false negatives, it does not make the checks tolerant of genuinely unreachable services. A regular service that fails to resolve still fails the sweep.
