### PR TITLE
fix(renovate): extend the shared preset by its current repository name [ready]

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>camunda/infex-common-config:default.json5"],
+  extends: ["github>camunda/infraex-common-config:default.json5"],
 }


### PR DESCRIPTION
## Why

`.github/renovate.json5` extends the shared preset under a repository name that no longer exists:

```json5
extends: ["github>camunda/infex-common-config:default.json5"]
```

`camunda/infex-common-config` was the name when this line was written (`857c3f5`, May 2024). The repository has since been renamed to `camunda/infraex-common-config`.

The preset **does** still resolve today — GitHub answers the former path with a redirect:

```
$ curl -sSo /dev/null -w '%{http_code} -> %{redirect_url}\n' \
    https://api.github.com/repos/camunda/infex-common-config/contents/default.json5
301 -> https://api.github.com/repositories/797759479/contents/default.json5
```

and the shared config is visibly in effect (the Dependency Dashboard shows the preset's `renovate/minor-grouped` branch). So this is not a live breakage.

It is a dependency on a redirect that is not a contract. Rename redirects stop the moment anything is created at the former name, and nothing warns when that happens: Renovate would simply fail to resolve the preset and fall back to its own defaults, quietly dropping every grouping, schedule and package rule this repository relies on.

## What

One name. `infex` → `infraex`. `renovate-config-validator --strict` passes.

This was the only occurrence left in the organisation (`gh search code "infex-common-config" --owner camunda`).
