### PR TITLE
ci: bump infraex-common-config lint-global to 2.3.5 [ready]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         # stops the job inheriting the repository default, which is write.
         permissions:
             contents: read
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@a05561ab3126f369c281352c776bdc103f622ccb # 2.3.5
         # Explicit rather than `secrets: inherit`, which hands every secret this repository holds
         # to a workflow whose main job installs and executes third-party pre-commit hook code.
         # These three are all it reads, and only on the auto-fix path.


### PR DESCRIPTION
Bumps the `lint-global` pin from 2.3.4 to [2.3.5](https://github.com/camunda/infraex-common-config/releases/tag/2.3.5).

What arrives with it, for this repository:

- a `renovate annotations` job that applies the shared preset's `customManagers` here and fails on any annotation extracting nothing or extracting several times, warning when the extracted version cannot match its own `versioning=regex:`. This repository holds no version annotation, so it reports `0 sound, 0 broken` — which is the point of bumping it here first: it exercises the cross-repository path (the reusable workflow checks its own source out at `job.workflow_repository` / `job.workflow_sha` to read the preset) somewhere nothing can break;
- the preset's custom manager rewrite from camunda/infraex-common-config#580 — no effect here, again for lack of annotations;
- the asdf and pre-commit cache changes from 2.3.4's successors, which shorten the lint job.

Renovate would open this bump on its own; it is done by hand to sequence it ahead of the repositories that do carry annotations.