### PR TITLE
chore(deps): update camunda/infraex-common-config to 2.3.6 [ready]

### DIFF
--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -26,4 +26,4 @@ jobs:
         # No `secrets: inherit`: todo-checker-global reads no secret at all, it works off
         # GITHUB_TOKEN and the permissions it declares itself. Inheriting would hand it every
         # secret this repository holds for nothing.
-        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
+        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@9d485973624ec326ef0e92c73191b6c0f26ad39e # 2.3.6

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Notify in Slack in case of failure
               id: slack-notification
               if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@26224a8e51a019dadec867d2c6413b81db1c4411 # 2.3.4
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@9d485973624ec326ef0e92c73191b6c0f26ad39e # 2.3.6
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         # stops the job inheriting the repository default, which is write.
         permissions:
             contents: read
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@a05561ab3126f369c281352c776bdc103f622ccb # 2.3.5
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@9d485973624ec326ef0e92c73191b6c0f26ad39e # 2.3.6
         # Explicit rather than `secrets: inherit`, which hands every secret this repository holds
         # to a workflow whose main job installs and executes third-party pre-commit hook code.
         # These three are all it reads, and only on the auto-fix path.


### PR DESCRIPTION
Pilot for the 2.3.4 -> 2.3.6 move across the repositories that consume this toolchain.

## Why not stay on 2.3.4

2.3.4 brought the pre-commit cache work — `restore-keys` ladder, narrower key, saves scoped to the default branch, the redundant apt step dropped, bounded `apt-get update` retries, timeout raised to 20 minutes — but `lint-global.yml` in 2.3.4 still pinned `asdf-install-tooling` at 2.3.3 internally:

```
asdf-install-tooling@887ed647... # 2.3.3
```

So the toolchain half is inert on 2.3.4: the asdf cache still rotates weekly, still hashes all of `.tool-versions`, and still has no fallback. That pin moved to 2.3.4 in camunda/infraex-common-config#579, released as 2.3.5 — which is what this bump is actually after. On `camunda/infraex-common-config` `main`, where `lint-global` resolves locally and therefore already has all of it, the lint job now runs in 33s to 50s with both caches hitting, against 9m58 cold the day before.

## What else comes with it

2.3.5 and 2.3.6 also add Renovate annotation checks to `lint-global` (camunda/infraex-common-config#581, #583, #584), including one that fails on an annotation resolving to nothing updatable. That is a behaviour change, not a cache change: if this repository has a stale `# renovate:` annotation, this pull request is where it surfaces.

## Verification

The lint run on this pull request is the check that matters, on both counts.