### PR TITLE
fix(aws-irsa): read the OpenSearch prerequisites per component [ready]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,16 @@ repos:
       rev: 0.2.3
       hooks:
           - id: yamlfmt
+
+    - repo: local
+      hooks:
+          # The checks are shell scripts driving a live cluster, so most of them can only be
+          # exercised end to end. The value-resolution logic that is pure computation is split
+          # into checks/kube/lib/ and unit-tested here, which is why this runs from pre-commit
+          # (and therefore from the lint workflow) rather than from a dedicated CI job.
+          - id: aws-irsa-opensearch-tests
+            name: aws-irsa OpenSearch prerequisites tests
+            language: script
+            entry: test/kube/aws-irsa-opensearch.test.sh
+            pass_filenames: false
+            files: ^(checks/kube/lib/|test/kube/)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options:
 
 ##### Notes:
 - The script will display which components are being checked for IRSA support for both PostgreSQL and OpenSearch.
+- The OpenSearch prerequisites are read per component (`orchestration.data.secondaryStorage.*`, `optimize.database.opensearch.*`). The deprecated `global.opensearch.*` and `global.elasticsearch.*` values are still accepted as a fallback on the chart versions that define them; chart 15.x removed them.
 - You can exclude specific components from the checks if necessary.
 - By default, the script will spawn debugging pods using the `amazonlinux:latest` container image in the cluster.
 - Basic Linux commands such as `sed`, `awk`, and `grep` will also be required for the script's operation.

--- a/checks/kube/aws-irsa.sh
+++ b/checks/kube/aws-irsa.sh
@@ -10,7 +10,10 @@ LVL_1_SCRIPT_NAME="$DIR_NAME/$SCRIPT_NAME"
 
 # shellcheck source=checks/kube/lib/aws-irsa-opensearch.sh
 # shellcheck source-path=SCRIPTDIR
-source "$DIR_NAME/lib/aws-irsa-opensearch.sh"
+source "$DIR_NAME/lib/aws-irsa-opensearch.sh" || {
+    echo 1>&2 "Error: unable to load $DIR_NAME/lib/aws-irsa-opensearch.sh. Run this script from a checkout of the repository so that checks/kube/lib/ is present. Aborting."
+    exit 1
+}
 
 # Default variables
 NAMESPACE="${NAMESPACE:-""}"

--- a/checks/kube/aws-irsa.sh
+++ b/checks/kube/aws-irsa.sh
@@ -8,6 +8,10 @@ SCRIPT_NAME=$(basename "$0")
 DIR_NAME=$(dirname "$0")
 LVL_1_SCRIPT_NAME="$DIR_NAME/$SCRIPT_NAME"
 
+# shellcheck source=checks/kube/lib/aws-irsa-opensearch.sh
+# shellcheck source-path=SCRIPTDIR
+source "$DIR_NAME/lib/aws-irsa-opensearch.sh"
+
 # Default variables
 NAMESPACE="${NAMESPACE:-""}"
 SCRIPT_STATUS_OUTPUT=0
@@ -638,43 +642,6 @@ EOF
     fi
 }
 
-check_irsa_opensearch_requirements() {
-    elasticsearch_enabled=$(echo "$HELM_CHART_VALUES" | jq -r '.global.elasticsearch.enabled')
-    if [[ -z "$elasticsearch_enabled" || "$elasticsearch_enabled" == "null" ]]; then
-        elasticsearch_enabled=$(echo "$HELM_CHART_DEFAULT_VALUES" | jq -r '.global.elasticsearch.enabled')
-    fi
-
-    opensearch_enabled=$(echo "$HELM_CHART_VALUES" | jq -r '.global.opensearch.enabled')
-    if [[ -z "$opensearch_enabled" || "$opensearch_enabled" == "null" ]]; then
-        opensearch_enabled=$(echo "$HELM_CHART_DEFAULT_VALUES" | jq -r '.global.opensearch.enabled')
-    fi
-
-    opensearch_aws_enabled=$(echo "$HELM_CHART_VALUES" | jq -r '.global.opensearch.aws.enabled')
-    if [[ -z "$opensearch_aws_enabled" || "$opensearch_aws_enabled" == "null" ]]; then
-        opensearch_aws_enabled=$(echo "$HELM_CHART_DEFAULT_VALUES" | jq -r '.global.opensearch.aws.enabled')
-    fi
-
-    # Perform the checks and output messages accordingly
-    if [[ "$elasticsearch_enabled" == "true" ]]; then
-        echo "[FAIL] IRSA is only supported for OpenSearch. Set global.elasticsearch.enabled to false and use OpenSearch instead." 1>&2
-        SCRIPT_STATUS_OUTPUT=51
-    fi
-
-    if [[ "$opensearch_enabled" != "true" ]]; then
-        echo "[FAIL] OpenSearch must be enabled for IRSA to work. Set global.opensearch.enabled to true." 1>&2
-        SCRIPT_STATUS_OUTPUT=51
-    fi
-
-    if [[ "$opensearch_aws_enabled" != "true" ]]; then
-        echo "[FAIL] OpenSearch AWS integration must be enabled. Set global.opensearch.aws.enabled to true." 1>&2
-        SCRIPT_STATUS_OUTPUT=51
-    fi
-
-    if [[ "$SCRIPT_STATUS_OUTPUT" -ne 51 ]]; then
-        echo "[OK] OpenSearch is correctly configured for IRSA support."
-    fi
-}
-
 check_opensearch_iam_enabled() {
     opensearch_url=$(echo "$HELM_CHART_VALUES" | jq -r '.global.opensearch.url.host')
 
@@ -782,7 +749,14 @@ check_opensearch_iam_enabled() {
 if [[ -n "$COMPONENTS_TO_CHECK_IRSA_OS" ]]; then
     # Use grep -q to check for exclusion
     if ! echo "$COMPONENTS_TO_CHECK_IRSA_OS" | grep -q -F -x -f <(printf '%s\n' "${EXCLUDE_COMPONENTS_ARRAY[@]}"); then
-        check_irsa_opensearch_requirements
+        # OS_SERVICE_ACCOUNTS holds the components that are actually being
+        # checked: the requested list minus the excluded and the disabled ones.
+        # The OpenSearch prerequisites are per-component since chart 15.x, so
+        # they are validated only for those.
+        OS_COMPONENTS_TO_VERIFY=$(echo "$OS_SERVICE_ACCOUNTS" | jq -r 'keys | join(",")')
+        if ! check_irsa_opensearch_requirements "$OS_COMPONENTS_TO_VERIFY" "$HELM_CHART_DEFAULT_VALUES" "$HELM_CHART_VALUES"; then
+            SCRIPT_STATUS_OUTPUT=51
+        fi
         check_opensearch_iam_enabled
     fi
 fi

--- a/checks/kube/aws-irsa.sh
+++ b/checks/kube/aws-irsa.sh
@@ -751,9 +751,8 @@ if [[ -n "$COMPONENTS_TO_CHECK_IRSA_OS" ]]; then
         # The OpenSearch prerequisites are per-component since chart 15.x, so
         # they are validated only for those.
         OS_COMPONENTS_TO_VERIFY=$(echo "$OS_SERVICE_ACCOUNTS" | jq -r 'keys | join(",")')
-        if ! camunda_resolve_effective_values "$HELM_CHART_DEFAULT_VALUES" "$HELM_CHART_VALUES"; then
-            SCRIPT_STATUS_OUTPUT=51
-        elif ! check_irsa_opensearch_requirements "$OS_COMPONENTS_TO_VERIFY" "$CAMUNDA_EFFECTIVE_VALUES" "$CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED"; then
+        if ! { camunda_resolve_effective_values "$HELM_CHART_DEFAULT_VALUES" "$HELM_CHART_VALUES" \
+            && check_irsa_opensearch_requirements "$OS_COMPONENTS_TO_VERIFY" "$CAMUNDA_EFFECTIVE_VALUES" "$CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED"; }; then
             SCRIPT_STATUS_OUTPUT=51
         fi
         check_opensearch_iam_enabled

--- a/checks/kube/aws-irsa.sh
+++ b/checks/kube/aws-irsa.sh
@@ -646,23 +646,17 @@ EOF
 }
 
 check_opensearch_iam_enabled() {
-    opensearch_url=$(echo "$HELM_CHART_VALUES" | jq -r '.global.opensearch.url.host')
+    # Resolved with the chart's precedence (component-scoped first, the
+    # deprecated global tree as a fallback) and from the same effective values as
+    # the prerequisites above, so both checks verify the same OpenSearch domain.
+    opensearch_url=$(camunda_opensearch_host "$CAMUNDA_EFFECTIVE_VALUES")
 
-    # Fallback to per-component paths (Camunda 8.8+: orchestration/optimize have their own opensearch config)
     if [[ -z "$opensearch_url" || "$opensearch_url" == "null" ]]; then
-        opensearch_url=$(echo "$HELM_CHART_VALUES" | jq -r '.optimize.database.opensearch.url.host // empty')
-    fi
-    if [[ -z "$opensearch_url" || "$opensearch_url" == "null" ]]; then
-        # orchestration stores the full URL, extract the host
-        local full_url
-        full_url=$(echo "$HELM_CHART_VALUES" | jq -r '.orchestration.data.secondaryStorage.opensearch.url // empty')
-        if [[ -n "$full_url" && "$full_url" != "null" ]]; then
-            opensearch_url=$(echo "$full_url" | sed -E 's|^https?://||' | sed -E 's|(/.*)||' | sed -E 's|:[0-9]+$||')
+        opensearch_url_hint="'.orchestration.data.secondaryStorage.opensearch.url' or '.optimize.database.opensearch.url.host'"
+        if [[ "$CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED" == "true" ]]; then
+            opensearch_url_hint="$opensearch_url_hint (or the deprecated '.global.opensearch.url.host')"
         fi
-    fi
-
-    if [[ -z "$opensearch_url" || "$opensearch_url" == "null" ]]; then
-        echo "[FAIL] The OpenSearch URL is not set. Please ensure that '.global.opensearch.url.host' or per-component opensearch URL is correctly specified in the Helm chart values." 1>&2
+        echo "[FAIL] The OpenSearch URL is not set. Please ensure that $opensearch_url_hint is correctly specified in the Helm chart values." 1>&2
         SCRIPT_STATUS_OUTPUT=61
         return
     fi
@@ -757,7 +751,9 @@ if [[ -n "$COMPONENTS_TO_CHECK_IRSA_OS" ]]; then
         # The OpenSearch prerequisites are per-component since chart 15.x, so
         # they are validated only for those.
         OS_COMPONENTS_TO_VERIFY=$(echo "$OS_SERVICE_ACCOUNTS" | jq -r 'keys | join(",")')
-        if ! check_irsa_opensearch_requirements "$OS_COMPONENTS_TO_VERIFY" "$HELM_CHART_DEFAULT_VALUES" "$HELM_CHART_VALUES"; then
+        if ! camunda_resolve_effective_values "$HELM_CHART_DEFAULT_VALUES" "$HELM_CHART_VALUES"; then
+            SCRIPT_STATUS_OUTPUT=51
+        elif ! check_irsa_opensearch_requirements "$OS_COMPONENTS_TO_VERIFY" "$CAMUNDA_EFFECTIVE_VALUES" "$CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED"; then
             SCRIPT_STATUS_OUTPUT=51
         fi
         check_opensearch_iam_enabled

--- a/checks/kube/lib/aws-irsa-opensearch.sh
+++ b/checks/kube/lib/aws-irsa-opensearch.sh
@@ -43,23 +43,21 @@ def optimize_storage_type:
 # effective values to spot keys the chart would silently ignore.
 CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ='((.global.opensearch != null) or (.global.elasticsearch != null))'
 
-# Verify that every component checked for OpenSearch IRSA is actually backed by
-# OpenSearch and configured for AWS authentication. Both the component-scoped
-# values and the deprecated global ones are honoured, with the same precedence
-# as the chart helpers (`orchestration.secondaryStorage`,
-# `optimize.effectiveOsAwsEnabled`).
+# Resolve, once per run, the configuration every OpenSearch check reads. Both
+# checks take the result as an argument, so they cannot disagree on which
+# database the deployment uses.
 #
-# $1: comma-separated list of components to check
-# $2: chart default values (JSON)
-# $3: deployed Helm values (JSON)
+# $1: chart default values (JSON)
+# $2: deployed Helm values (JSON)
 #
-# Returns non-zero when at least one prerequisite is not met.
-check_irsa_opensearch_requirements() {
-    local components="$1" defaults="$2" values="$3"
-    local merged global_supported failed=0
-    local component component_failed enable_value aws_value
-    local storage_type aws_enabled
-    local os_component_list=()
+# Sets CAMUNDA_EFFECTIVE_VALUES and CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED.
+CAMUNDA_EFFECTIVE_VALUES=""
+CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED=false
+# CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED is an output of this library: it is
+# read by checks/kube/aws-irsa.sh and by the tests, never within this file.
+# shellcheck disable=SC2034
+camunda_resolve_effective_values() {
+    local defaults="$1" values="$2"
 
     if [[ -z "$defaults" || "$defaults" == "null" ]]; then
         defaults='{}'
@@ -72,7 +70,7 @@ check_irsa_opensearch_requirements() {
     # document holding the effective configuration. jq's `*` merges objects
     # recursively with the right-hand side winning, which is how Helm layers
     # user values over the chart defaults.
-    if ! merged=$(jq -n --argjson defaults "$defaults" --argjson values "$values" '$defaults * $values'); then
+    if ! CAMUNDA_EFFECTIVE_VALUES=$(jq -n --argjson defaults "$defaults" --argjson values "$values" '$defaults * $values'); then
         echo "[FAIL] Unable to merge the chart default values with the deployed Helm values." 1>&2
         return 1
     fi
@@ -83,20 +81,67 @@ check_irsa_opensearch_requirements() {
     # number, so the check follows the chart through the deprecation window
     # instead of needing a bump on the removal release.
     if [[ "$(jq -r "$CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ" <<< "$defaults")" == "true" ]]; then
-        global_supported=true
+        CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED=true
         echo "[INFO] The deployed chart still defines the deprecated global.elasticsearch/global.opensearch values; they are accepted as a fallback for the component-scoped ones."
-    else
-        global_supported=false
-        echo "[INFO] The deployed chart does not define the global.elasticsearch/global.opensearch values (removed in chart 15.x); only the component-scoped values are read."
-
-        # The deployed chart ignores these keys, so leaving them in the
-        # effective values would let a stale global.opensearch.enabled satisfy a
-        # check the chart itself would not honour (false positive).
-        if [[ "$(jq -r "$CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ" <<< "$merged")" == "true" ]]; then
-            echo "[WARN] global.elasticsearch/global.opensearch are set in your values but the deployed chart no longer consumes them; they are ignored." 1>&2
-            merged=$(jq 'del(.global.elasticsearch, .global.opensearch)' <<< "$merged")
-        fi
+        return 0
     fi
+
+    CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED=false
+    echo "[INFO] The deployed chart does not define the global.elasticsearch/global.opensearch values (removed in chart 15.x); only the component-scoped values are read."
+
+    # The deployed chart ignores these keys, so leaving them in the effective
+    # values would let a stale global.opensearch.enabled satisfy a check the
+    # chart itself would not honour (false positive).
+    if [[ "$(jq -r "$CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ" <<< "$CAMUNDA_EFFECTIVE_VALUES")" == "true" ]]; then
+        echo "[WARN] global.elasticsearch/global.opensearch are set in your values but the deployed chart no longer consumes them; they are ignored." 1>&2
+        CAMUNDA_EFFECTIVE_VALUES=$(jq 'del(.global.elasticsearch, .global.opensearch)' <<< "$CAMUNDA_EFFECTIVE_VALUES")
+    fi
+}
+
+# Resolve the OpenSearch host the deployment talks to, with the chart's own
+# precedence: the component-scoped values first, the deprecated global tree only
+# as a fallback (`camundaPlatform.opensearchHost`). Orchestration carries a full
+# URL where Optimize and the global tree carry a bare host, so the scheme, path
+# and port are stripped uniformly.
+#
+# $1: effective values (JSON)
+camunda_opensearch_host() {
+    local merged="$1"
+
+    # The resolution can be skipped when the values failed to merge; report no
+    # host rather than letting jq fail on an empty document.
+    if [[ -z "$merged" || "$merged" == "null" ]]; then
+        return 0
+    fi
+
+    jq -r '
+      def host_of: sub("^[a-z]+://"; "") | sub("/.*$"; "") | sub(":[0-9]+$"; "");
+      [ .orchestration.data.secondaryStorage.opensearch.url,
+        .optimize.database.opensearch.url.host,
+        .global.opensearch.url.host ]
+      | map(select(type == "string" and . != ""))
+      | (first // "")
+      | host_of
+    ' <<< "$merged"
+}
+
+# Verify that every component checked for OpenSearch IRSA is actually backed by
+# OpenSearch and configured for AWS authentication. Both the component-scoped
+# values and the deprecated global ones are honoured, with the same precedence
+# as the chart helpers (`orchestration.secondaryStorage`,
+# `optimize.effectiveOsAwsEnabled`).
+#
+# $1: comma-separated list of components to check
+# $2: effective values (JSON), from camunda_resolve_effective_values
+# $3: whether the chart still supports the global database values
+#
+# Returns non-zero when at least one prerequisite is not met.
+check_irsa_opensearch_requirements() {
+    local components="$1" merged="$2" global_supported="$3"
+    local failed=0
+    local component component_failed enable_value aws_value
+    local storage_type aws_enabled
+    local os_component_list=()
 
     IFS=',' read -r -a os_component_list <<< "$components"
     if [[ "${#os_component_list[@]}" -eq 0 ]]; then

--- a/checks/kube/lib/aws-irsa-opensearch.sh
+++ b/checks/kube/lib/aws-irsa-opensearch.sh
@@ -65,12 +65,20 @@ check_irsa_opensearch_requirements() {
     # read from the deployed chart's own defaults rather than from its version
     # number, so the check follows the chart through the deprecation window
     # instead of needing a bump on the removal release.
-    if [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$merged")" == "true" ]]; then
+    if [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$defaults")" == "true" ]]; then
         global_supported=true
         echo "[INFO] The deployed chart still defines the deprecated global.elasticsearch/global.opensearch values; they are accepted as a fallback for the component-scoped ones."
     else
         global_supported=false
         echo "[INFO] The deployed chart does not define the global.elasticsearch/global.opensearch values (removed in chart 15.x); only the component-scoped values are read."
+
+        # The deployed chart ignores these keys, so leaving them in the
+        # effective values would let a stale global.opensearch.enabled satisfy a
+        # check the chart itself would not honour (false positive).
+        if [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$merged")" == "true" ]]; then
+            echo "[WARN] global.elasticsearch/global.opensearch are set in your values but the deployed chart no longer consumes them; they are ignored." 1>&2
+            merged=$(jq 'del(.global.elasticsearch, .global.opensearch)' <<< "$merged")
+        fi
     fi
 
     IFS=',' read -r -a os_component_list <<< "$components"

--- a/checks/kube/lib/aws-irsa-opensearch.sh
+++ b/checks/kube/lib/aws-irsa-opensearch.sh
@@ -26,38 +26,6 @@ def orchestration_storage_type:
   end;
 '
 
-# Coalesce the chart defaults with the deployed values into a single document
-# holding the effective configuration. jq's `*` merges objects recursively with
-# the right-hand side winning, which is how Helm layers user values over the
-# chart defaults.
-#
-# $1: chart default values (JSON)
-# $2: deployed Helm values (JSON)
-camunda_effective_values() {
-    local defaults="$1" values="$2"
-
-    if [[ -z "$defaults" || "$defaults" == "null" ]]; then
-        defaults='{}'
-    fi
-    if [[ -z "$values" || "$values" == "null" ]]; then
-        values='{}'
-    fi
-
-    jq -n --argjson defaults "$defaults" --argjson values "$values" '$defaults * $values'
-}
-
-# Whether the deployed chart still defines the deprecated global database value
-# trees. Chart 15.x deletes `global.elasticsearch` and `global.opensearch` in
-# favour of the component-scoped values. This is read from the chart's own
-# defaults rather than from its version number, so the check follows the chart
-# through the deprecation window instead of needing a bump on the removal
-# release.
-#
-# $1: effective values (JSON)
-camunda_chart_supports_global_database_values() {
-    [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$1")" == "true" ]]
-}
-
 # Verify that every component checked for OpenSearch IRSA is actually backed by
 # OpenSearch and configured for AWS authentication. Both the component-scoped
 # values and the deprecated global ones are honoured, with the same precedence
@@ -76,12 +44,28 @@ check_irsa_opensearch_requirements() {
     local storage_type os_enabled es_enabled aws_enabled
     local os_component_list=()
 
-    if ! merged=$(camunda_effective_values "$defaults" "$values"); then
+    if [[ -z "$defaults" || "$defaults" == "null" ]]; then
+        defaults='{}'
+    fi
+    if [[ -z "$values" || "$values" == "null" ]]; then
+        values='{}'
+    fi
+
+    # Coalesce the chart defaults with the deployed values into a single
+    # document holding the effective configuration. jq's `*` merges objects
+    # recursively with the right-hand side winning, which is how Helm layers
+    # user values over the chart defaults.
+    if ! merged=$(jq -n --argjson defaults "$defaults" --argjson values "$values" '$defaults * $values'); then
         echo "[FAIL] Unable to merge the chart default values with the deployed Helm values." 1>&2
         return 1
     fi
 
-    if camunda_chart_supports_global_database_values "$merged"; then
+    # Chart 15.x deletes `global.elasticsearch` and `global.opensearch` in
+    # favour of the component-scoped values. Whether they are still supported is
+    # read from the deployed chart's own defaults rather than from its version
+    # number, so the check follows the chart through the deprecation window
+    # instead of needing a bump on the removal release.
+    if [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$merged")" == "true" ]]; then
         global_supported=true
         echo "[INFO] The deployed chart still defines the deprecated global.elasticsearch/global.opensearch values; they are accepted as a fallback for the component-scoped ones."
     else
@@ -90,6 +74,11 @@ check_irsa_opensearch_requirements() {
     fi
 
     IFS=',' read -r -a os_component_list <<< "$components"
+    if [[ "${#os_component_list[@]}" -eq 0 ]]; then
+        echo "[INFO] No component is being checked for OpenSearch IRSA; skipping the OpenSearch prerequisites."
+        return 0
+    fi
+
     for component in "${os_component_list[@]}"; do
         if [[ -z "$component" ]]; then
             continue

--- a/checks/kube/lib/aws-irsa-opensearch.sh
+++ b/checks/kube/lib/aws-irsa-opensearch.sh
@@ -6,10 +6,13 @@
 # resolution can be exercised without a cluster; see
 # test/kube/aws-irsa-opensearch.test.sh.
 
-# jq port of the chart's `orchestration.secondaryStorage` helper. The explicit
-# `type` wins outright; only when it is empty does the chart derive the storage
-# from the exporter flags and from the (deprecated) global tree.
-CAMUNDA_ORCHESTRATION_STORAGE_TYPE_JQ='
+# jq port of the chart helpers that decide which database a component talks to
+# (`orchestration.secondaryStorage` and `optimize.indexPrefix` in
+# camunda-platform-helm). Both live here so they stay diffable against the
+# chart, and both answer in the chart's own secondary-storage vocabulary rather
+# than in a pair of booleans. The component-scoped values win; the deprecated
+# global tree is only consulted as a fallback.
+CAMUNDA_SECONDARY_STORAGE_JQ='
 def orchestration_storage_type:
   if ((.orchestration.data.secondaryStorage.type // "") != "") then
     .orchestration.data.secondaryStorage.type
@@ -24,7 +27,21 @@ def orchestration_storage_type:
   else
     "unset"
   end;
+
+def optimize_storage_type:
+  if ((.global.elasticsearch.enabled // false) or (.optimize.database.elasticsearch.enabled // false)) then
+    "elasticsearch"
+  elif ((.global.opensearch.enabled // false) or (.optimize.database.opensearch.enabled // false)) then
+    "opensearch"
+  else
+    "unset"
+  end;
 '
+
+# Whether a set of Helm values still carries the deprecated global database
+# trees. Used against the chart defaults to decide support, then against the
+# effective values to spot keys the chart would silently ignore.
+CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ='((.global.opensearch != null) or (.global.elasticsearch != null))'
 
 # Verify that every component checked for OpenSearch IRSA is actually backed by
 # OpenSearch and configured for AWS authentication. Both the component-scoped
@@ -41,7 +58,7 @@ check_irsa_opensearch_requirements() {
     local components="$1" defaults="$2" values="$3"
     local merged global_supported failed=0
     local component component_failed enable_value aws_value
-    local storage_type os_enabled es_enabled aws_enabled
+    local storage_type aws_enabled
     local os_component_list=()
 
     if [[ -z "$defaults" || "$defaults" == "null" ]]; then
@@ -65,7 +82,7 @@ check_irsa_opensearch_requirements() {
     # read from the deployed chart's own defaults rather than from its version
     # number, so the check follows the chart through the deprecation window
     # instead of needing a bump on the removal release.
-    if [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$defaults")" == "true" ]]; then
+    if [[ "$(jq -r "$CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ" <<< "$defaults")" == "true" ]]; then
         global_supported=true
         echo "[INFO] The deployed chart still defines the deprecated global.elasticsearch/global.opensearch values; they are accepted as a fallback for the component-scoped ones."
     else
@@ -75,7 +92,7 @@ check_irsa_opensearch_requirements() {
         # The deployed chart ignores these keys, so leaving them in the
         # effective values would let a stale global.opensearch.enabled satisfy a
         # check the chart itself would not honour (false positive).
-        if [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$merged")" == "true" ]]; then
+        if [[ "$(jq -r "$CAMUNDA_HAS_GLOBAL_DATABASE_VALUES_JQ" <<< "$merged")" == "true" ]]; then
             echo "[WARN] global.elasticsearch/global.opensearch are set in your values but the deployed chart no longer consumes them; they are ignored." 1>&2
             merged=$(jq 'del(.global.elasticsearch, .global.opensearch)' <<< "$merged")
         fi
@@ -94,27 +111,13 @@ check_irsa_opensearch_requirements() {
 
         case "$component" in
             orchestration)
-                storage_type=$(jq -r "${CAMUNDA_ORCHESTRATION_STORAGE_TYPE_JQ} orchestration_storage_type" <<< "$merged")
-                echo "[INFO] (component=$component) Resolved secondary storage type: $storage_type"
-
-                if [[ "$storage_type" == "opensearch" ]]; then
-                    os_enabled=true
-                else
-                    os_enabled=false
-                fi
-                if [[ "$storage_type" == "elasticsearch" ]]; then
-                    es_enabled=true
-                else
-                    es_enabled=false
-                fi
-
+                storage_type=$(jq -r "${CAMUNDA_SECONDARY_STORAGE_JQ} orchestration_storage_type" <<< "$merged")
                 aws_enabled=$(jq -r '((.orchestration.data.secondaryStorage.opensearch.aws.enabled // false) or (.global.opensearch.aws.enabled // false))' <<< "$merged")
                 enable_value='orchestration.data.secondaryStorage.type to "opensearch"'
                 aws_value="orchestration.data.secondaryStorage.opensearch.aws.enabled to true"
                 ;;
             optimize)
-                os_enabled=$(jq -r '((.optimize.database.opensearch.enabled // false) or (.global.opensearch.enabled // false))' <<< "$merged")
-                es_enabled=$(jq -r '((.optimize.database.elasticsearch.enabled // false) or (.global.elasticsearch.enabled // false))' <<< "$merged")
+                storage_type=$(jq -r "${CAMUNDA_SECONDARY_STORAGE_JQ} optimize_storage_type" <<< "$merged")
                 aws_enabled=$(jq -r '((.optimize.database.opensearch.aws.enabled // false) or (.global.opensearch.aws.enabled // false))' <<< "$merged")
                 enable_value="optimize.database.opensearch.enabled to true"
                 aws_value="optimize.database.opensearch.aws.enabled to true"
@@ -125,6 +128,8 @@ check_irsa_opensearch_requirements() {
                 ;;
         esac
 
+        echo "[INFO] (component=$component) Resolved secondary storage type: $storage_type"
+
         if [[ "$global_supported" == "true" ]]; then
             enable_value="$enable_value (or the deprecated global.opensearch.enabled to true)"
             aws_value="$aws_value (or the deprecated global.opensearch.aws.enabled to true)"
@@ -132,13 +137,18 @@ check_irsa_opensearch_requirements() {
 
         component_failed=0
 
-        if [[ "$es_enabled" == "true" ]]; then
-            echo "[FAIL] (component=$component) IRSA is only supported for OpenSearch, but the deployed values select Elasticsearch. Set $enable_value." 1>&2
-            component_failed=1
-        elif [[ "$os_enabled" != "true" ]]; then
-            echo "[FAIL] (component=$component) OpenSearch must be enabled for IRSA to work. Set $enable_value." 1>&2
-            component_failed=1
-        fi
+        case "$storage_type" in
+            opensearch)
+                ;;
+            elasticsearch)
+                echo "[FAIL] (component=$component) IRSA is only supported for OpenSearch, but the deployed values select Elasticsearch. Set $enable_value." 1>&2
+                component_failed=1
+                ;;
+            *)
+                echo "[FAIL] (component=$component) OpenSearch must be enabled for IRSA to work. Set $enable_value." 1>&2
+                component_failed=1
+                ;;
+        esac
 
         if [[ "$aws_enabled" != "true" ]]; then
             echo "[FAIL] (component=$component) OpenSearch AWS integration must be enabled. Set $aws_value." 1>&2

--- a/checks/kube/lib/aws-irsa-opensearch.sh
+++ b/checks/kube/lib/aws-irsa-opensearch.sh
@@ -1,0 +1,159 @@
+# shellcheck shell=bash
+#
+# Resolution of the OpenSearch IRSA prerequisites from the deployed Helm values.
+#
+# Sourced by checks/kube/aws-irsa.sh. It lives in its own file so the value
+# resolution can be exercised without a cluster; see
+# test/kube/aws-irsa-opensearch.test.sh.
+
+# jq port of the chart's `orchestration.secondaryStorage` helper. The explicit
+# `type` wins outright; only when it is empty does the chart derive the storage
+# from the exporter flags and from the (deprecated) global tree.
+CAMUNDA_ORCHESTRATION_STORAGE_TYPE_JQ='
+def orchestration_storage_type:
+  if ((.orchestration.data.secondaryStorage.type // "") != "") then
+    .orchestration.data.secondaryStorage.type
+  elif (.global.noSecondaryStorage // false) then
+    "none"
+  elif (.orchestration.exporters.rdbms.enabled // false) then
+    "rdbms"
+  elif ((.global.elasticsearch.enabled // false) or (.optimize.database.elasticsearch.enabled // false)) then
+    "elasticsearch"
+  elif ((.global.opensearch.enabled // false) or (.optimize.database.opensearch.enabled // false)) then
+    "opensearch"
+  else
+    "unset"
+  end;
+'
+
+# Coalesce the chart defaults with the deployed values into a single document
+# holding the effective configuration. jq's `*` merges objects recursively with
+# the right-hand side winning, which is how Helm layers user values over the
+# chart defaults.
+#
+# $1: chart default values (JSON)
+# $2: deployed Helm values (JSON)
+camunda_effective_values() {
+    local defaults="$1" values="$2"
+
+    if [[ -z "$defaults" || "$defaults" == "null" ]]; then
+        defaults='{}'
+    fi
+    if [[ -z "$values" || "$values" == "null" ]]; then
+        values='{}'
+    fi
+
+    jq -n --argjson defaults "$defaults" --argjson values "$values" '$defaults * $values'
+}
+
+# Whether the deployed chart still defines the deprecated global database value
+# trees. Chart 15.x deletes `global.elasticsearch` and `global.opensearch` in
+# favour of the component-scoped values. This is read from the chart's own
+# defaults rather than from its version number, so the check follows the chart
+# through the deprecation window instead of needing a bump on the removal
+# release.
+#
+# $1: effective values (JSON)
+camunda_chart_supports_global_database_values() {
+    [[ "$(jq -r '((.global.opensearch != null) or (.global.elasticsearch != null))' <<< "$1")" == "true" ]]
+}
+
+# Verify that every component checked for OpenSearch IRSA is actually backed by
+# OpenSearch and configured for AWS authentication. Both the component-scoped
+# values and the deprecated global ones are honoured, with the same precedence
+# as the chart helpers (`orchestration.secondaryStorage`,
+# `optimize.effectiveOsAwsEnabled`).
+#
+# $1: comma-separated list of components to check
+# $2: chart default values (JSON)
+# $3: deployed Helm values (JSON)
+#
+# Returns non-zero when at least one prerequisite is not met.
+check_irsa_opensearch_requirements() {
+    local components="$1" defaults="$2" values="$3"
+    local merged global_supported failed=0
+    local component component_failed enable_value aws_value
+    local storage_type os_enabled es_enabled aws_enabled
+    local os_component_list=()
+
+    if ! merged=$(camunda_effective_values "$defaults" "$values"); then
+        echo "[FAIL] Unable to merge the chart default values with the deployed Helm values." 1>&2
+        return 1
+    fi
+
+    if camunda_chart_supports_global_database_values "$merged"; then
+        global_supported=true
+        echo "[INFO] The deployed chart still defines the deprecated global.elasticsearch/global.opensearch values; they are accepted as a fallback for the component-scoped ones."
+    else
+        global_supported=false
+        echo "[INFO] The deployed chart does not define the global.elasticsearch/global.opensearch values (removed in chart 15.x); only the component-scoped values are read."
+    fi
+
+    IFS=',' read -r -a os_component_list <<< "$components"
+    for component in "${os_component_list[@]}"; do
+        if [[ -z "$component" ]]; then
+            continue
+        fi
+
+        case "$component" in
+            orchestration)
+                storage_type=$(jq -r "${CAMUNDA_ORCHESTRATION_STORAGE_TYPE_JQ} orchestration_storage_type" <<< "$merged")
+                echo "[INFO] (component=$component) Resolved secondary storage type: $storage_type"
+
+                if [[ "$storage_type" == "opensearch" ]]; then
+                    os_enabled=true
+                else
+                    os_enabled=false
+                fi
+                if [[ "$storage_type" == "elasticsearch" ]]; then
+                    es_enabled=true
+                else
+                    es_enabled=false
+                fi
+
+                aws_enabled=$(jq -r '((.orchestration.data.secondaryStorage.opensearch.aws.enabled // false) or (.global.opensearch.aws.enabled // false))' <<< "$merged")
+                enable_value='orchestration.data.secondaryStorage.type to "opensearch"'
+                aws_value="orchestration.data.secondaryStorage.opensearch.aws.enabled to true"
+                ;;
+            optimize)
+                os_enabled=$(jq -r '((.optimize.database.opensearch.enabled // false) or (.global.opensearch.enabled // false))' <<< "$merged")
+                es_enabled=$(jq -r '((.optimize.database.elasticsearch.enabled // false) or (.global.elasticsearch.enabled // false))' <<< "$merged")
+                aws_enabled=$(jq -r '((.optimize.database.opensearch.aws.enabled // false) or (.global.opensearch.aws.enabled // false))' <<< "$merged")
+                enable_value="optimize.database.opensearch.enabled to true"
+                aws_value="optimize.database.opensearch.aws.enabled to true"
+                ;;
+            *)
+                echo "[INFO] (component=$component) No OpenSearch prerequisites are defined for this component, skipping."
+                continue
+                ;;
+        esac
+
+        if [[ "$global_supported" == "true" ]]; then
+            enable_value="$enable_value (or the deprecated global.opensearch.enabled to true)"
+            aws_value="$aws_value (or the deprecated global.opensearch.aws.enabled to true)"
+        fi
+
+        component_failed=0
+
+        if [[ "$es_enabled" == "true" ]]; then
+            echo "[FAIL] (component=$component) IRSA is only supported for OpenSearch, but the deployed values select Elasticsearch. Set $enable_value." 1>&2
+            component_failed=1
+        elif [[ "$os_enabled" != "true" ]]; then
+            echo "[FAIL] (component=$component) OpenSearch must be enabled for IRSA to work. Set $enable_value." 1>&2
+            component_failed=1
+        fi
+
+        if [[ "$aws_enabled" != "true" ]]; then
+            echo "[FAIL] (component=$component) OpenSearch AWS integration must be enabled. Set $aws_value." 1>&2
+            component_failed=1
+        fi
+
+        if [[ "$component_failed" -eq 0 ]]; then
+            echo "[OK] (component=$component) OpenSearch is correctly configured for IRSA support."
+        else
+            failed=1
+        fi
+    done
+
+    return "$failed"
+}

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,15 @@
 # Tests
 
+## Unit tests
+
+The parts of the checks that are pure value resolution live in `checks/*/lib/` and are covered by
+`*.test.sh` scripts next to this file. They need no cluster and run from pre-commit:
+
+```shell
+pre-commit run --all-files
+./test/kube/aws-irsa-opensearch.test.sh   # or run one directly
+```
+
 ## Setup a Kind cluster
 
 Setup a kind cluster https://docs.camunda.io/docs/self-managed/setup/deploy/local/local-kubernetes-cluster/.

--- a/test/kube/aws-irsa-opensearch.test.sh
+++ b/test/kube/aws-irsa-opensearch.test.sh
@@ -121,6 +121,19 @@ run_case "legacy: no database configured is rejected" \
     "[FAIL] (component=orchestration) OpenSearch must be enabled" \
     "[FAIL] (component=optimize) OpenSearch must be enabled"
 
+# The chart resolves Optimize's database with `optimize.indexPrefix`, which
+# tests Elasticsearch before OpenSearch. A deployment that enables both must be
+# reported as Elasticsearch, like the chart would use it.
+run_case "optimize mirrors the chart's elasticsearch-first precedence" \
+    "optimize" "$LEGACY_DEFAULTS" \
+    '{
+      "global": {"elasticsearch": {"enabled": true}},
+      "optimize": {"database": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}
+    }' \
+    1 \
+    "[INFO] (component=optimize) Resolved secondary storage type: elasticsearch" \
+    "[FAIL] (component=optimize) IRSA is only supported for OpenSearch"
+
 # --- Component-scoped values (chart 15.x) ------------------------------------
 
 run_case "chart 15: component-scoped opensearch with AWS mode passes" \

--- a/test/kube/aws-irsa-opensearch.test.sh
+++ b/test/kube/aws-irsa-opensearch.test.sh
@@ -168,6 +168,15 @@ run_case "chart 15: no database configured is rejected" \
     "[FAIL] (component=orchestration) OpenSearch must be enabled" \
     "[FAIL] (component=optimize) OpenSearch must be enabled"
 
+run_case "chart 15: global values the chart no longer consumes do not satisfy the check" \
+    "orchestration,optimize" "$CHART_15_DEFAULTS" \
+    '{"global": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}' \
+    1 \
+    "[WARN] global.elasticsearch/global.opensearch are set in your values but the deployed chart no longer consumes them" \
+    "[FAIL] (component=orchestration) OpenSearch must be enabled" \
+    "[FAIL] (component=optimize) OpenSearch must be enabled" \
+    "[FAIL] (component=optimize) OpenSearch AWS integration must be enabled"
+
 # --- Component selection ------------------------------------------------------
 
 run_case "only the requested components are verified" \

--- a/test/kube/aws-irsa-opensearch.test.sh
+++ b/test/kube/aws-irsa-opensearch.test.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+# Unit tests for the OpenSearch IRSA prerequisite resolution
+# (checks/kube/lib/aws-irsa-opensearch.sh).
+#
+# They cover the two value layouts the check has to support: the legacy global
+# tree (charts up to 14.x) and the component-scoped one that replaces it in
+# chart 15.x, where `global.elasticsearch` and `global.opensearch` are gone.
+#
+# Usage: ./test/kube/aws-irsa-opensearch.test.sh
+
+set -o pipefail
+
+TEST_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck source=../../checks/kube/lib/aws-irsa-opensearch.sh
+# shellcheck source-path=SCRIPTDIR
+source "$TEST_DIR/../../checks/kube/lib/aws-irsa-opensearch.sh"
+
+command -v jq >/dev/null 2>&1 || { echo 1>&2 "Error: jq is required but not installed. Aborting."; exit 1; }
+
+FAILURES=0
+
+# Chart defaults up to 14.x: the deprecated global database trees are still
+# defined alongside the component-scoped ones. Only the keys the check reads are
+# reproduced here.
+LEGACY_DEFAULTS='{
+  "global": {
+    "elasticsearch": {"enabled": false},
+    "opensearch": {"enabled": false, "aws": {"enabled": false}}
+  },
+  "orchestration": {
+    "data": {"secondaryStorage": {"type": "", "opensearch": {"aws": {"enabled": false}}}},
+    "exporters": {"rdbms": {"enabled": false}}
+  },
+  "optimize": {
+    "database": {
+      "elasticsearch": {"enabled": false},
+      "opensearch": {"enabled": false, "aws": {"enabled": false}}
+    }
+  }
+}'
+
+# Chart 15.x defaults: same tree with global.elasticsearch and global.opensearch
+# removed (camunda/camunda-platform-helm#6914).
+CHART_15_DEFAULTS='{
+  "orchestration": {
+    "data": {"secondaryStorage": {"type": "", "opensearch": {"aws": {"enabled": false}}}},
+    "exporters": {"rdbms": {"enabled": false}}
+  },
+  "optimize": {
+    "database": {
+      "elasticsearch": {"enabled": false},
+      "opensearch": {"enabled": false, "aws": {"enabled": false}}
+    }
+  }
+}'
+
+# run_case <name> <components> <defaults> <values> <expected status> [pattern...]
+#
+# Each pattern must appear in the combined output; a pattern prefixed with "!"
+# must not.
+run_case() {
+    local name="$1" components="$2" defaults="$3" values="$4" expected_status="$5"
+    shift 5
+    local output status pattern
+    local before="$FAILURES"
+
+    output=$(check_irsa_opensearch_requirements "$components" "$defaults" "$values" 2>&1)
+    status=$?
+
+    if [[ "$status" -ne "$expected_status" ]]; then
+        printf '[FAIL] %s: expected exit status %s, got %s\n%s\n' "$name" "$expected_status" "$status" "$output"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+
+    for pattern in "$@"; do
+        if [[ "$pattern" == "!"* ]]; then
+            if grep -qF -- "${pattern#!}" <<< "$output"; then
+                printf '[FAIL] %s: output should not contain "%s"\n%s\n' "$name" "${pattern#!}" "$output"
+                FAILURES=$((FAILURES + 1))
+            fi
+        elif ! grep -qF -- "$pattern" <<< "$output"; then
+            printf '[FAIL] %s: output should contain "%s"\n%s\n' "$name" "$pattern" "$output"
+            FAILURES=$((FAILURES + 1))
+        fi
+    done
+
+    if [[ "$FAILURES" -eq "$before" ]]; then
+        printf '[OK] %s\n' "$name"
+    fi
+}
+
+# --- Legacy global values (charts up to 14.x) --------------------------------
+
+run_case "legacy: global opensearch with AWS mode passes" \
+    "orchestration,optimize" "$LEGACY_DEFAULTS" \
+    '{"global": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}' \
+    0 \
+    "[OK] (component=orchestration)" \
+    "[OK] (component=optimize)"
+
+run_case "legacy: elasticsearch selected is rejected" \
+    "orchestration,optimize" "$LEGACY_DEFAULTS" \
+    '{"global": {"elasticsearch": {"enabled": true}, "opensearch": {"aws": {"enabled": true}}}}' \
+    1 \
+    "[FAIL] (component=orchestration) IRSA is only supported for OpenSearch" \
+    "[FAIL] (component=optimize) IRSA is only supported for OpenSearch"
+
+run_case "legacy: opensearch without AWS mode is rejected and names the global value" \
+    "orchestration,optimize" "$LEGACY_DEFAULTS" \
+    '{"global": {"opensearch": {"enabled": true}}}' \
+    1 \
+    "[FAIL] (component=orchestration) OpenSearch AWS integration must be enabled" \
+    "global.opensearch.aws.enabled to true"
+
+run_case "legacy: no database configured is rejected" \
+    "orchestration,optimize" "$LEGACY_DEFAULTS" '{}' \
+    1 \
+    "[FAIL] (component=orchestration) OpenSearch must be enabled" \
+    "[FAIL] (component=optimize) OpenSearch must be enabled"
+
+# --- Component-scoped values (chart 15.x) ------------------------------------
+
+run_case "chart 15: component-scoped opensearch with AWS mode passes" \
+    "orchestration,optimize" "$CHART_15_DEFAULTS" \
+    '{
+      "orchestration": {"data": {"secondaryStorage": {"type": "opensearch", "opensearch": {"aws": {"enabled": true}}}}},
+      "optimize": {"database": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}
+    }' \
+    0 \
+    "[OK] (component=orchestration)" \
+    "[OK] (component=optimize)" \
+    "!Set global.opensearch"
+
+run_case "chart 15: missing AWS mode names the component-scoped values" \
+    "orchestration,optimize" "$CHART_15_DEFAULTS" \
+    '{
+      "orchestration": {"data": {"secondaryStorage": {"type": "opensearch"}}},
+      "optimize": {"database": {"opensearch": {"enabled": true}}}
+    }' \
+    1 \
+    "Set orchestration.data.secondaryStorage.opensearch.aws.enabled to true." \
+    "Set optimize.database.opensearch.aws.enabled to true." \
+    "!global.opensearch.aws.enabled"
+
+run_case "chart 15: elasticsearch selected is rejected" \
+    "orchestration,optimize" "$CHART_15_DEFAULTS" \
+    '{
+      "orchestration": {"data": {"secondaryStorage": {"type": "elasticsearch"}}},
+      "optimize": {"database": {"elasticsearch": {"enabled": true}}}
+    }' \
+    1 \
+    '[FAIL] (component=orchestration) IRSA is only supported for OpenSearch, but the deployed values select Elasticsearch. Set orchestration.data.secondaryStorage.type to "opensearch".' \
+    "[FAIL] (component=optimize) IRSA is only supported for OpenSearch"
+
+run_case "chart 15: rdbms secondary storage is rejected" \
+    "orchestration" "$CHART_15_DEFAULTS" \
+    '{"orchestration": {"data": {"secondaryStorage": {"type": "rdbms"}}}}' \
+    1 \
+    "Resolved secondary storage type: rdbms" \
+    "[FAIL] (component=orchestration) OpenSearch must be enabled"
+
+run_case "chart 15: no database configured is rejected" \
+    "orchestration,optimize" "$CHART_15_DEFAULTS" '{}' \
+    1 \
+    "[FAIL] (component=orchestration) OpenSearch must be enabled" \
+    "[FAIL] (component=optimize) OpenSearch must be enabled"
+
+# --- Component selection ------------------------------------------------------
+
+run_case "only the requested components are verified" \
+    "orchestration" "$CHART_15_DEFAULTS" \
+    '{"orchestration": {"data": {"secondaryStorage": {"type": "opensearch", "opensearch": {"aws": {"enabled": true}}}}}}' \
+    0 \
+    "[OK] (component=orchestration)" \
+    "!component=optimize"
+
+run_case "an unknown component is skipped" \
+    "connectors" "$CHART_15_DEFAULTS" '{}' \
+    0 \
+    "[INFO] (component=connectors) No OpenSearch prerequisites are defined"
+
+run_case "an empty component list verifies nothing" \
+    "" "$CHART_15_DEFAULTS" '{}' 0 \
+    "!component="
+
+# --- Value coalescing ---------------------------------------------------------
+
+run_case "deployed values override the chart defaults" \
+    "optimize" \
+    '{"optimize": {"database": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}}' \
+    '{"optimize": {"database": {"opensearch": {"aws": {"enabled": false}}}}}' \
+    1 \
+    "[FAIL] (component=optimize) OpenSearch AWS integration must be enabled"
+
+run_case "absent deployed values fall back to the chart defaults" \
+    "optimize" \
+    '{"optimize": {"database": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}}' \
+    "" 0 \
+    "[OK] (component=optimize)"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+    printf '\n%s: %s check(s) failed.\n' "$0" "$FAILURES" 1>&2
+    exit 1
+fi
+
+printf '\n%s: all checks passed.\n' "$0"

--- a/test/kube/aws-irsa-opensearch.test.sh
+++ b/test/kube/aws-irsa-opensearch.test.sh
@@ -21,6 +21,16 @@ command -v jq >/dev/null 2>&1 || { echo 1>&2 "Error: jq is required but not inst
 
 FAILURES=0
 
+# assert_equals <name> <expected> <actual>
+assert_equals() {
+    if [[ "$3" == "$2" ]]; then
+        printf '[OK] %s\n' "$1"
+    else
+        printf '[FAIL] %s: expected "%s", got "%s"\n' "$1" "$2" "$3"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
 # Chart defaults up to 14.x: the deprecated global database trees are still
 # defined alongside the component-scoped ones. Only the keys the check reads are
 # reproduced here.
@@ -41,20 +51,10 @@ LEGACY_DEFAULTS='{
   }
 }'
 
-# Chart 15.x defaults: same tree with global.elasticsearch and global.opensearch
-# removed (camunda/camunda-platform-helm#6914).
-CHART_15_DEFAULTS='{
-  "orchestration": {
-    "data": {"secondaryStorage": {"type": "", "opensearch": {"aws": {"enabled": false}}}},
-    "exporters": {"rdbms": {"enabled": false}}
-  },
-  "optimize": {
-    "database": {
-      "elasticsearch": {"enabled": false},
-      "opensearch": {"enabled": false, "aws": {"enabled": false}}
-    }
-  }
-}'
+# Chart 15.x defaults: the same tree with the global database values removed
+# (camunda/camunda-platform-helm#6914). Derived from the legacy fixture so the
+# two cannot drift apart as the reproduced key set grows.
+CHART_15_DEFAULTS=$(jq -c 'del(.global)' <<< "$LEGACY_DEFAULTS")
 
 # run_case <name> <components> <defaults> <values> <expected status> [pattern...]
 #
@@ -233,17 +233,8 @@ run_case "absent deployed values fall back to the chart defaults" \
 
 # assert_host <name> <defaults> <values> <expected host>
 assert_host() {
-    local name="$1" defaults="$2" values="$3" expected="$4" actual
-
-    camunda_resolve_effective_values "$defaults" "$values" >/dev/null 2>&1
-    actual=$(camunda_opensearch_host "$CAMUNDA_EFFECTIVE_VALUES")
-
-    if [[ "$actual" == "$expected" ]]; then
-        printf '[OK] %s\n' "$name"
-    else
-        printf '[FAIL] %s: expected host "%s", got "%s"\n' "$name" "$expected" "$actual"
-        FAILURES=$((FAILURES + 1))
-    fi
+    camunda_resolve_effective_values "$2" "$3" >/dev/null 2>&1
+    assert_equals "$1" "$4" "$(camunda_opensearch_host "$CAMUNDA_EFFECTIVE_VALUES")"
 }
 
 assert_host "host: orchestration full URL is stripped to the host" \
@@ -279,12 +270,7 @@ assert_host "host: nothing configured resolves to empty" \
 
 # The URL check runs even when the merge failed; it must report no host instead
 # of tripping over an empty document.
-if [[ -n "$(camunda_opensearch_host "")" ]]; then
-    printf '[FAIL] host: an unresolved document should yield no host\n'
-    FAILURES=$((FAILURES + 1))
-else
-    printf '[OK] host: an unresolved document yields no host\n'
-fi
+assert_equals "host: an unresolved document yields no host" "" "$(camunda_opensearch_host "")"
 
 if [[ "$FAILURES" -ne 0 ]]; then
     printf '\n%s: %s check(s) failed.\n' "$0" "$FAILURES" 1>&2

--- a/test/kube/aws-irsa-opensearch.test.sh
+++ b/test/kube/aws-irsa-opensearch.test.sh
@@ -66,7 +66,8 @@ run_case() {
     local output status pattern
     local before="$FAILURES"
 
-    output=$(check_irsa_opensearch_requirements "$components" "$defaults" "$values" 2>&1)
+    output=$( { camunda_resolve_effective_values "$defaults" "$values" \
+        && check_irsa_opensearch_requirements "$components" "$CAMUNDA_EFFECTIVE_VALUES" "$CAMUNDA_GLOBAL_DATABASE_VALUES_SUPPORTED"; } 2>&1 )
     status=$?
 
     if [[ "$status" -ne "$expected_status" ]]; then
@@ -223,6 +224,67 @@ run_case "absent deployed values fall back to the chart defaults" \
     '{"optimize": {"database": {"opensearch": {"enabled": true, "aws": {"enabled": true}}}}}' \
     "" 0 \
     "[OK] (component=optimize)"
+
+# --- OpenSearch host resolution ----------------------------------------------
+#
+# The URL check must agree with the prerequisites above on which cluster is
+# being verified, so it resolves with the chart's own precedence
+# (`camundaPlatform.opensearchHost`): component-scoped first, global last.
+
+# assert_host <name> <defaults> <values> <expected host>
+assert_host() {
+    local name="$1" defaults="$2" values="$3" expected="$4" actual
+
+    camunda_resolve_effective_values "$defaults" "$values" >/dev/null 2>&1
+    actual=$(camunda_opensearch_host "$CAMUNDA_EFFECTIVE_VALUES")
+
+    if [[ "$actual" == "$expected" ]]; then
+        printf '[OK] %s\n' "$name"
+    else
+        printf '[FAIL] %s: expected host "%s", got "%s"\n' "$name" "$expected" "$actual"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_host "host: orchestration full URL is stripped to the host" \
+    "$CHART_15_DEFAULTS" \
+    '{"orchestration": {"data": {"secondaryStorage": {"opensearch": {"url": "https://vpc-os.eu-west-1.es.amazonaws.com:443/path"}}}}}' \
+    "vpc-os.eu-west-1.es.amazonaws.com"
+
+assert_host "host: optimize host is used when orchestration has none" \
+    "$CHART_15_DEFAULTS" \
+    '{"optimize": {"database": {"opensearch": {"url": {"host": "optimize-os.eu-west-1.es.amazonaws.com"}}}}}' \
+    "optimize-os.eu-west-1.es.amazonaws.com"
+
+assert_host "host: the component-scoped value wins over the deprecated global one" \
+    "$LEGACY_DEFAULTS" \
+    '{
+      "global": {"opensearch": {"url": {"host": "stale-global.eu-west-1.es.amazonaws.com"}}},
+      "optimize": {"database": {"opensearch": {"url": {"host": "real-component.eu-west-1.es.amazonaws.com"}}}}
+    }' \
+    "real-component.eu-west-1.es.amazonaws.com"
+
+assert_host "host: the deprecated global value is still a fallback on charts that define it" \
+    "$LEGACY_DEFAULTS" \
+    '{"global": {"opensearch": {"url": {"host": "legacy-global.eu-west-1.es.amazonaws.com"}}}}' \
+    "legacy-global.eu-west-1.es.amazonaws.com"
+
+assert_host "host: a global value the chart dropped is ignored" \
+    "$CHART_15_DEFAULTS" \
+    '{"global": {"opensearch": {"url": {"host": "stale-global.eu-west-1.es.amazonaws.com"}}}}' \
+    ""
+
+assert_host "host: nothing configured resolves to empty" \
+    "$CHART_15_DEFAULTS" '{}' ""
+
+# The URL check runs even when the merge failed; it must report no host instead
+# of tripping over an empty document.
+if [[ -n "$(camunda_opensearch_host "")" ]]; then
+    printf '[FAIL] host: an unresolved document should yield no host\n'
+    FAILURES=$((FAILURES + 1))
+else
+    printf '[OK] host: an unresolved document yields no host\n'
+fi
 
 if [[ "$FAILURES" -ne 0 ]]; then
     printf '\n%s: %s check(s) failed.\n' "$0" "$FAILURES" 1>&2

--- a/test/kube/aws-irsa-opensearch.test.sh
+++ b/test/kube/aws-irsa-opensearch.test.sh
@@ -184,6 +184,7 @@ run_case "an unknown component is skipped" \
 
 run_case "an empty component list verifies nothing" \
     "" "$CHART_15_DEFAULTS" '{}' 0 \
+    "[INFO] No component is being checked for OpenSearch IRSA" \
     "!component="
 
 # --- Value coalescing ---------------------------------------------------------


### PR DESCRIPTION
Closes #338

## Problem

Chart 15.x removes the `global.elasticsearch` and `global.opensearch` value trees (camunda/camunda-platform-helm#6914). `check_irsa_opensearch_requirements` only read:

- `.global.elasticsearch.enabled`
- `.global.opensearch.enabled`
- `.global.opensearch.aws.enabled`

On a valid chart 15.x deployment configured through `orchestration.data.secondaryStorage.*` and `optimize.database.opensearch.*`, those lookups resolve to `null`, fall back to the chart defaults (`false`), and the check reports OpenSearch and AWS integration as disabled on a correctly configured cluster.

## Change

The enablement and AWS-mode lookups now mirror the chart helpers (`orchestration.secondaryStorage`, `optimize.effectiveOsAwsEnabled`): the component-scoped value wins, the global one is a fallback.

- **orchestration** — `orchestration.data.secondaryStorage.type` when set, otherwise the chart's own derivation from the exporter flags and the global tree; AWS mode from `orchestration.data.secondaryStorage.opensearch.aws.enabled` or `global.opensearch.aws.enabled`.
- **optimize** — `optimize.database.opensearch.enabled` or `global.opensearch.enabled`; AWS mode from `optimize.database.opensearch.aws.enabled` or `global.opensearch.aws.enabled`.

Whether the global tree is supported is read from the deployed chart's **own defaults** rather than from its version number, following the pattern already used for `camundaHub.*` in the webModeler branch. A version gate would misjudge the 8.10 charts that still honour the deprecated values today, and would need another bump on the removal release.

The prerequisites are now validated for each component being checked (the requested list minus the excluded and the disabled ones), because the values they read are per component. Failure messages name the value the deployed chart actually consumes, so a chart 15.x user is not told to set a key that no longer exists.

### Adjacent fix: OpenSearch host precedence

`check_opensearch_iam_enabled` read `.global.opensearch.url.host` **first** and only then the component-scoped paths. The chart resolves the opposite way (`camundaPlatform.opensearchHost` = `optimize.database.opensearch.url.host` then `global.opensearch.url.host`).

Left alone, this PR would have made the two adjacent checks disagree: the prerequisites would resolve component-first while the domain, access-policy, HTTPS and nmap checks stayed global-first. On a deployment carrying a stale global host next to the real component-scoped one, the script would validate one cluster and probe another.

Both now share a single effective-values document and a single deprecation verdict (`camunda_resolve_effective_values`), so they cannot disagree by construction. The URL failure message names the component-scoped values too, which is the last part of acceptance criterion 4.

## Tests

`checks/kube/aws-irsa.sh` needs a live cluster, an AWS account and a Helm release, so the resolution logic — which is pure computation — moves to `checks/kube/lib/aws-irsa-opensearch.sh` and is unit-tested in `test/kube/aws-irsa-opensearch.test.sh`.

Coverage includes both value layouts required by the issue: a legacy global-values input and a chart-15 component-scoped one, plus Elasticsearch and RDBMS rejection, component selection, and the defaults/values coalescing.

The suite runs as a `local` pre-commit hook, so it executes in the existing `lint` workflow rather than needing a new CI job.

## Verification

```console
$ ./test/kube/aws-irsa-opensearch.test.sh
[OK] legacy: global opensearch with AWS mode passes
[OK] legacy: elasticsearch selected is rejected
[OK] legacy: opensearch without AWS mode is rejected and names the global value
[OK] legacy: no database configured is rejected
[OK] optimize mirrors the chart's elasticsearch-first precedence
[OK] chart 15: component-scoped opensearch with AWS mode passes
[OK] chart 15: missing AWS mode names the component-scoped values
[OK] chart 15: elasticsearch selected is rejected
[OK] chart 15: rdbms secondary storage is rejected
[OK] chart 15: no database configured is rejected
[OK] chart 15: global values the chart no longer consumes do not satisfy the check
[OK] only the requested components are verified
[OK] an unknown component is skipped
[OK] an empty component list verifies nothing
[OK] deployed values override the chart defaults
[OK] absent deployed values fall back to the chart defaults
[OK] host: orchestration full URL is stripped to the host
[OK] host: optimize host is used when orchestration has none
[OK] host: the component-scoped value wins over the deprecated global one
[OK] host: the deprecated global value is still a fallback on charts that define it
[OK] host: a global value the chart dropped is ignored
[OK] host: nothing configured resolves to empty
[OK] host: an unresolved document yields no host
```

`pre-commit run --all-files` passes.